### PR TITLE
Forget array

### DIFF
--- a/t1p_constructor.c
+++ b/t1p_constructor.c
@@ -141,6 +141,10 @@ tbool_t t1p_is_eq(ap_manager_t* man, t1p_t* a, t1p_t* b)
 		res = t1p_aff_is_eq(pr, a->paf[i], b->paf[i]);
 		if (!res) break;
 	    } else {
+		// proposed FIX
+                if (a->paf[i] == b->paf[i]) {
+		    continue;
+                }
 		res = false;
 		break;
 	    }

--- a/t1p_otherops.c
+++ b/t1p_otherops.c
@@ -43,6 +43,8 @@ t1p_t* t1p_forget_array(ap_manager_t* man,
 	    t1p_aff_check_free(pr, res->paf[tdim[i]]);
 	    res->paf[tdim[i]] = pr->top;
 	    res->paf[tdim[i]]->pby++;
+	    // proposed fix
+	    itv_set_top(res->box[i]);
 	}
     }
     return res;
@@ -284,7 +286,7 @@ void ap_abstract1_aff_build(ap_manager_t* man, ap_abstract1_t* abstract1, ap_var
     ap_dim_t dim = ap_environment_dim_of_var(abstract1->env,var);
     t1p_t* abs = (t1p_t*)abstract1->abstract0->value;
     itv_set_ap_interval(pr->itv, itv, interval);
-    /* on admet que les formes sont affines autrement dit pas réduite à un intervalle avec une borne infinie */
+    /* on admet que les formes sont affines autrement dit pas rÃ©duite Ã  un intervalle avec une borne infinie */
     if (pr->dim <= index) t1p_aff_nsym_create(pr, abs->paf[dim], itv, isunion ? UN : IN);
     else t1p_aff_build(pr, abs->paf[dim], itv, index);
     //if (isunion) abs->paf[dim]->lastu = abs->paf[dim]->end;

--- a/tests/test4.c
+++ b/tests/test4.c
@@ -1,0 +1,40 @@
+#include <time.h>
+#include "t1p.h"
+#include <string.h>
+#include <stdio.h>
+
+ap_abstract0_t * create_zonotope(ap_manager_t* man, int dim,
+		double values[dim][2]) {
+	ap_interval_t** intervals = ap_interval_array_alloc(dim);
+	int i;
+	for (i = 0; i < dim; i++) {
+		ap_interval_set_double(intervals[i], values[i][0], values[i][1]);
+	}
+	ap_abstract0_t * zonotope = ap_abstract0_of_box(man, dim, 0, intervals);
+	return zonotope;
+}
+
+int main(int argc, char **argv) {
+	int dim = 2;
+
+	ap_manager_t* man = t1p_manager_alloc();
+
+	double values1[2][2] = { { 0, 0 }, { -6469, -1121 }};
+
+	ap_abstract0_t* zonotope1 = create_zonotope(man, dim, values1);
+	printf("zonotope1:\n");
+	ap_abstract0_fprint(stdout, man, zonotope1, NULL);
+
+	ap_dim_t * tdim = (ap_dim_t *) malloc(sizeof(ap_dim_t));
+	tdim[0] = 0;
+
+	ap_abstract0_t* zonotope2 = ap_abstract0_forget_array(man, false, zonotope1,
+			tdim, 1, false);
+	printf("zonotope2:\n");
+	ap_abstract0_fprint(stdout, man, zonotope2, NULL);
+
+	//should be false
+	printf("zonotope2 <= zonotope1 : %d\n",
+			ap_abstract0_is_leq(man, zonotope2, zonotope1));
+	return 0;
+}

--- a/tests/test5.c
+++ b/tests/test5.c
@@ -1,0 +1,44 @@
+#include <time.h>
+#include "t1p.h"
+#include <string.h>
+#include <stdio.h>
+
+ap_abstract0_t * create_zonotope(ap_manager_t* man, int dim,
+		double values[dim][2]) {
+	ap_interval_t** intervals = ap_interval_array_alloc(dim);
+	int i;
+	for (i = 0; i < dim; i++) {
+		ap_interval_set_double(intervals[i], values[i][0], values[i][1]);
+	}
+	ap_abstract0_t * zonotope = ap_abstract0_of_box(man, dim, 0, intervals);
+	return zonotope;
+}
+
+int main(int argc, char **argv) {
+	int dim = 2;
+
+	ap_manager_t* man = t1p_manager_alloc();
+	ap_abstract0_t* bottom = ap_abstract0_bottom(man, dim, 0);
+
+	double values1[2][2] = { { 0, 0 }, { -6469, -1121 } };
+
+	ap_abstract0_t* zonotope1 = create_zonotope(man, dim, values1);
+	printf("zonotope1:\n");
+	ap_abstract0_fprint(stdout, man, zonotope1, NULL);
+
+	ap_dim_t * tdim = (ap_dim_t *) malloc(sizeof(ap_dim_t));
+	tdim[0] = 0;
+
+	ap_abstract0_t* zonotope2 = ap_abstract0_join(man, false, zonotope1,
+			bottom);
+	printf("zonotope2:\n");
+	ap_abstract0_fprint(stdout, man, zonotope2, NULL);
+
+	printf("zonotope1 <= zonotope2 : %d\n",
+			ap_abstract0_is_leq(man, zonotope1, zonotope2));
+	printf("zonotope2 <= zonotope1 : %d\n",
+			ap_abstract0_is_leq(man, zonotope2, zonotope1));
+	printf("zonotope1 == zonotope2 : %d\n",
+			ap_abstract0_is_eq(man, zonotope1, zonotope2));
+	return 0;
+}

--- a/tests/test9.c
+++ b/tests/test9.c
@@ -1,0 +1,41 @@
+#include <time.h>
+#include "t1p.h"
+#include <string.h>
+#include <stdio.h>
+
+ap_abstract0_t * create_zonotope(ap_manager_t* man, int dim,
+		double values[dim][2]) {
+	ap_interval_t** intervals = ap_interval_array_alloc(dim);
+	int i;
+	for (i = 0; i < dim; i++) {
+		ap_interval_set_double(intervals[i], values[i][0], values[i][1]);
+	}
+	ap_abstract0_t * zonotope = ap_abstract0_of_box(man, dim, 0, intervals);
+	return zonotope;
+}
+
+int main(int argc, char **argv) {
+	int dim = 2;
+
+	ap_manager_t* man = t1p_manager_alloc();
+
+	double values1[2][2] = { { 0, 0 }, { -6469,-1121 }};
+	ap_abstract0_t* zonotope1 = create_zonotope(man, dim, values1);
+	ap_abstract0_fprint(stdout, man, zonotope1, NULL);
+
+	double values2[2][2] = { {-14, 2885 }, { 1, 7 }};
+
+	ap_abstract0_t* zonotope2 = create_zonotope(man, dim, values2);
+	ap_abstract0_fprint(stdout, man, zonotope2, NULL);
+
+	ap_abstract0_t* zonotope12 = ap_abstract0_join(man, false, zonotope1,
+			zonotope2);
+
+	ap_abstract0_t* zonotope21 = ap_abstract0_join(man, false, zonotope2, zonotope1);
+	printf("Join12 result:\n");
+	ap_abstract0_fprint(stdout, man, zonotope12, NULL);
+	printf("Join21 result:\n");
+	ap_abstract0_fprint(stdout, man, zonotope21, NULL);
+	printf("join12 = join21:%d\n", ap_abstract0_is_eq(man, zonotope12, zonotope21));
+	return 0;
+}


### PR DESCRIPTION
I have attached a test case which gives an unexpected result after forget_array, with project = false. The corresponding variable is set to top, but the resulting zonotope seems to be included in the original one (the less equal test returns true). My impression is that the forget_array function only sets to top the affine form. My colleague Gagandeep Singh suggested a fix. @kghorbal could you please check if this is correct? Thank you very much.