### PR TITLE
Equality

### DIFF
--- a/t1p_constructor.c
+++ b/t1p_constructor.c
@@ -141,6 +141,10 @@ tbool_t t1p_is_eq(ap_manager_t* man, t1p_t* a, t1p_t* b)
 		res = t1p_aff_is_eq(pr, a->paf[i], b->paf[i]);
 		if (!res) break;
 	    } else {
+		// proposed FIX
+                if (a->paf[i] == b->paf[i]) {
+		    continue;
+                }
 		res = false;
 		break;
 	    }

--- a/tests/test5.c
+++ b/tests/test5.c
@@ -1,0 +1,44 @@
+#include <time.h>
+#include "t1p.h"
+#include <string.h>
+#include <stdio.h>
+
+ap_abstract0_t * create_zonotope(ap_manager_t* man, int dim,
+		double values[dim][2]) {
+	ap_interval_t** intervals = ap_interval_array_alloc(dim);
+	int i;
+	for (i = 0; i < dim; i++) {
+		ap_interval_set_double(intervals[i], values[i][0], values[i][1]);
+	}
+	ap_abstract0_t * zonotope = ap_abstract0_of_box(man, dim, 0, intervals);
+	return zonotope;
+}
+
+int main(int argc, char **argv) {
+	int dim = 2;
+
+	ap_manager_t* man = t1p_manager_alloc();
+	ap_abstract0_t* bottom = ap_abstract0_bottom(man, dim, 0);
+
+	double values1[2][2] = { { 0, 0 }, { -6469, -1121 } };
+
+	ap_abstract0_t* zonotope1 = create_zonotope(man, dim, values1);
+	printf("zonotope1:\n");
+	ap_abstract0_fprint(stdout, man, zonotope1, NULL);
+
+	ap_dim_t * tdim = (ap_dim_t *) malloc(sizeof(ap_dim_t));
+	tdim[0] = 0;
+
+	ap_abstract0_t* zonotope2 = ap_abstract0_join(man, false, zonotope1,
+			bottom);
+	printf("zonotope2:\n");
+	ap_abstract0_fprint(stdout, man, zonotope2, NULL);
+
+	printf("zonotope1 <= zonotope2 : %d\n",
+			ap_abstract0_is_leq(man, zonotope1, zonotope2));
+	printf("zonotope2 <= zonotope1 : %d\n",
+			ap_abstract0_is_leq(man, zonotope2, zonotope1));
+	printf("zonotope1 == zonotope2 : %d\n",
+			ap_abstract0_is_eq(man, zonotope1, zonotope2));
+	return 0;
+}

--- a/tests/test9.c
+++ b/tests/test9.c
@@ -1,0 +1,41 @@
+#include <time.h>
+#include "t1p.h"
+#include <string.h>
+#include <stdio.h>
+
+ap_abstract0_t * create_zonotope(ap_manager_t* man, int dim,
+		double values[dim][2]) {
+	ap_interval_t** intervals = ap_interval_array_alloc(dim);
+	int i;
+	for (i = 0; i < dim; i++) {
+		ap_interval_set_double(intervals[i], values[i][0], values[i][1]);
+	}
+	ap_abstract0_t * zonotope = ap_abstract0_of_box(man, dim, 0, intervals);
+	return zonotope;
+}
+
+int main(int argc, char **argv) {
+	int dim = 2;
+
+	ap_manager_t* man = t1p_manager_alloc();
+
+	double values1[2][2] = { { 0, 0 }, { -6469,-1121 }};
+	ap_abstract0_t* zonotope1 = create_zonotope(man, dim, values1);
+	ap_abstract0_fprint(stdout, man, zonotope1, NULL);
+
+	double values2[2][2] = { {-14, 2885 }, { 1, 7 }};
+
+	ap_abstract0_t* zonotope2 = create_zonotope(man, dim, values2);
+	ap_abstract0_fprint(stdout, man, zonotope2, NULL);
+
+	ap_abstract0_t* zonotope12 = ap_abstract0_join(man, false, zonotope1,
+			zonotope2);
+
+	ap_abstract0_t* zonotope21 = ap_abstract0_join(man, false, zonotope2, zonotope1);
+	printf("Join12 result:\n");
+	ap_abstract0_fprint(stdout, man, zonotope12, NULL);
+	printf("Join21 result:\n");
+	ap_abstract0_fprint(stdout, man, zonotope21, NULL);
+	printf("join12 = join21:%d\n", ap_abstract0_is_eq(man, zonotope12, zonotope21));
+	return 0;
+}


### PR DESCRIPTION
I have attached a test which fails due to the equality check (test5.c): zonotope1 <= zonotope2 is true and zonotope2 <= zonotope1 is true as well, but zonotope1 = zonotope2 returns false. I modified t1p_is_eq and now the test passes. The problem is that for other tests (such as test9.c), the equality check still returns false, even if the two zonotopes are equal. I tried to debug test9.c and I think the problem is not in the t1p_is_eq anymore, but my impression is that t1p_aff_join_constrained6 has unexpected results. Unfortunately I don't know how to fix it. @kghorbal could you please help me? Thanks a lot.